### PR TITLE
Add tlr legality to fix issues with decklist retrieval

### DIFF
--- a/.changeset/eighty-terms-throw.md
+++ b/.changeset/eighty-terms-throw.md
@@ -1,0 +1,5 @@
+---
+"moxfield-api": patch
+---
+
+Add Tiny Leaders Reborn (TLR) to list of legalities

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "moxfield-api",
-	"version": "1.0.3",
+	"version": "1.0.2",
 	"description": "A Javascript library for https://moxfield.com written in Typescript.",
 	"keywords": [
 		"deck",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "moxfield-api",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "A Javascript library for https://moxfield.com written in Typescript.",
 	"keywords": [
 		"deck",

--- a/src/schema/legalities/legalities.schema.ts
+++ b/src/schema/legalities/legalities.schema.ts
@@ -23,6 +23,7 @@ const LegalitiesFormatSchema = z.union([
 	z.literal('standard'),
 	z.literal('standardbrawl'),
 	z.literal('timeless'),
+	z.literal('tlr'),
 	z.literal('vintage'),
 ]);
 


### PR DESCRIPTION
## Description

Recently, I noticed that an app I made which uses `moxfield-api` started failing. After looking into it, and pasting the error into my nearest LLM to decipher, it turns out that Moxfield has updated the legalities in their list to include "TLR". That stands for [Tiny Leaders Reborn](https://official-tlr.com/about/), and it is a competitive-focused commander-alike format. 

So to fix this library, I've updated the Zod schema to support "tlr". 

## Validation

I built the package with my changes, copied over the artifacts into my app's `node_modules`, and confirmed that the deck retrieval worked.

I did also run the unit tests, but almost all of them failed. However, they also fail on `main`, and some of the Moxfield URLs it tests against don't seem to exist anymore (404 pages). I'm going to suggest that it's not important those tests pass for this PR to merge.